### PR TITLE
add: pass drafting agent log function to adhoc agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "beaker-kernel~=1.9.3",
+  "beaker-kernel~=1.9.4",
   "archytas~=1.3.18",
-  "adhoc-api~=2.2.0",  
+  "adhoc-api~=2.3.0",
   "requests",
   "PyYAML",
   "idc-index",

--- a/src/biome/agent.py
+++ b/src/biome/agent.py
@@ -129,6 +129,12 @@ class BiomeAgent(BaseAgent):
             self.__doc__ = template.format(api_list=self.api_list, instructions=self.instructions)
             self.add_context(self.__doc__)
 
+    def log(self, event_type: str, content = None) -> None:
+        self.context.beaker_kernel.log(
+            event_type=f"agent_{event_type}",
+            content=content
+        )
+
     @tool()
     @with_docstring('draft_api_code.md')
     async def draft_api_code(self, api: str, goal: str, agent: AgentRef, loop: LoopControllerRef, react_context: ReactContextRef) -> str:


### PR DESCRIPTION
Relies on 

https://github.com/jataware/beaker-kernel/pull/106

and

https://github.com/jataware/adhoc-api/pull/7

to add example messages and transparency to the adhoc agent.